### PR TITLE
uv and github actions: set update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ docs = [
     "pygments>=2.19.2",
 ]
 
+[tool.uv]
+# Exclude dependency releases newer than 1 week, in order to reduce supply-chain
+# risk.
+exclude-newer = "1 week"
+
 [tool.uv.sources]
 # Until pygments does another release, we should take it from git. Otherwise,
 # our documentation's t-strings will be formatted incorrectly.


### PR DESCRIPTION
This ensures that dependency versions newer than 1 week are not considered for installation, to help reduce the risk of supply-chain attacks.